### PR TITLE
Crawl for geom_alt prop updates

### DIFF
--- a/data/101/914/185/101914185.geojson
+++ b/data/101/914/185/101914185.geojson
@@ -921,6 +921,9 @@
         85688891
     ],
     "wof:country":"VA",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f1edda57c5327561cd5c17a698c9fb3a",
     "wof:hierarchy":[
         {
@@ -934,7 +937,7 @@
     "wof:lang":[
         "ita"
     ],
-    "wof:lastmodified":1566644081,
+    "wof:lastmodified":1582393294,
     "wof:megacity":0,
     "wof:name":"Citt\u00e0 del Vaticano",
     "wof:parent_id":85688891,

--- a/data/856/321/87/85632187.geojson
+++ b/data/856/321/87/85632187.geojson
@@ -1146,6 +1146,9 @@
     ],
     "wof:country":"VA",
     "wof:country_alpha3":"VAT",
+    "wof:geom_alt":[
+        "naturalearth-display-terrestrial-zoom6"
+    ],
     "wof:geomhash":"f1edda57c5327561cd5c17a698c9fb3a",
     "wof:hierarchy":[
         {
@@ -1158,7 +1161,7 @@
     "wof:lang_x_spoken":[
         "ita"
     ],
-    "wof:lastmodified":1566644081,
+    "wof:lastmodified":1582393294,
     "wof:name":"Vatican",
     "wof:parent_id":102191581,
     "wof:placetype":"country",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.