### PR TITLE
va concordances, placetype local, and more

### DIFF
--- a/data/856/321/87/85632187.geojson
+++ b/data/856/321/87/85632187.geojson
@@ -1294,6 +1294,7 @@
         "gp:id":23424986,
         "hasc:id":"VA",
         "icao:code":"HV",
+        "iso:code":"VA",
         "itu:id":"CVA",
         "loc:id":"n80053295",
         "m49:code":"336",
@@ -1307,6 +1308,7 @@
         "wd:id":"Q237",
         "wk:page":"Vatican City"
     },
+    "wof:concordances_official":"iso:code",
     "wof:coterminous":[
         101914185,
         85688891
@@ -1328,7 +1330,7 @@
     "wof:lang_x_spoken":[
         "ita"
     ],
-    "wof:lastmodified":1694639671,
+    "wof:lastmodified":1695881330,
     "wof:name":"Vatican",
     "wof:parent_id":102191581,
     "wof:placetype":"country",

--- a/data/856/888/91/85688891.geojson
+++ b/data/856/888/91/85688891.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000057,
-    "geom:area_square_m":520046.408469,
+    "geom:area_square_m":520036.247412,
     "geom:bbox":"12.445909,41.900276,12.458336,41.907417",
     "geom:latitude":41.903395,
     "geom:longitude":12.452965,
@@ -131,14 +131,16 @@
     "wof:concordances":{
         "fips:code":"VT",
         "hasc:id":"VA.VA",
+        "iso:code":"VA-VA",
         "iso:id":"VA-VA"
     },
+    "wof:concordances_official":"iso:code",
     "wof:coterminous":[
         101914185,
         85632187
     ],
     "wof:country":"VA",
-    "wof:geomhash":"f1edda57c5327561cd5c17a698c9fb3a",
+    "wof:geomhash":"4b393c82c45fd756c3f769c697538955",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -150,7 +152,7 @@
     "wof:lang_x_spoken":[
         "ita"
     ],
-    "wof:lastmodified":1636506408,
+    "wof:lastmodified":1695884972,
     "wof:name":"Vatican",
     "wof:parent_id":85632187,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.